### PR TITLE
fix: adjust_options with both data and file

### DIFF
--- a/src/legacy/api.rs
+++ b/src/legacy/api.rs
@@ -440,7 +440,9 @@ impl From<LegacyOptions> for StringOptions {
 impl LegacyOptions {
   pub(crate) fn adjust_options(mut self) -> Self {
     if let Some(file) = &self.file {
-      if self.indented_syntax.is_some() || self.importers.is_some() {
+      if self.data.is_none()
+        && (self.indented_syntax.is_some() || self.importers.is_some())
+      {
         self.data = Some(fs::read_to_string(file).unwrap());
         self.indented_syntax = Some(self.indented_syntax.unwrap_or_default());
       }

--- a/tests/compile_spec.rs
+++ b/tests/compile_spec.rs
@@ -500,6 +500,22 @@ mod compile_string {
         assert_eq!(err.span().unwrap().start.line, 0);
         assert_eq!(err.span().unwrap().url.as_ref().unwrap(), &url);
       }
+
+      #[test]
+      fn with_multi_span_errors() {
+        let sandbox = Sandbox::default();
+        let url = sandbox.path().join("foo.scss").to_url();
+
+        let mut sass = Sass::new(exe_path()).unwrap();
+        let err = sass
+          .compile_string(
+            "@use \"sass:math\"; @use \"sass:math\"",
+            StringOptionsBuilder::default().url(url.clone()).build(),
+          )
+          .unwrap_err();
+        assert_eq!(err.span().unwrap().start.line, 0);
+        assert_eq!(err.span().unwrap().url.as_ref().unwrap(), &url);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes using options with both data, file and indented_syntax or importers, then data is been rewritten in `adjust_options`.